### PR TITLE
(docs) update external contributor to use develop branch as well

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -99,7 +99,7 @@ git pull --rebase origin development
 
 ##### External Developer
 ```bash
-git pull --rebase upstream master
+git pull --rebase upstream development
 ```
 
 This will start the rebase process. You must commit all of your changes


### PR DESCRIPTION
Update external developer branch from `master` to `development` for rebasing

[trello ticket](https://trello.com/c/hBPqW8LA/48-update-readme-to-reflect-contributing-workflow)