### PR TITLE
(bug) fix incorrect file path for server build script

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "[Contributing Guidelines](CONTRIBUTING.md)",
   "main": "server/index.js",
   "scripts": {
-    "build": "webpack --config webpack.prod.config.js && babel src -d server-dist",
+    "build": "webpack --config webpack.prod.config.js && babel server -d server-dist",
     "start:dev": "nodemon --exec NODE_ENV=development babel-node server/index.js",
     "test": "jest",
     "coverage": "npx jest --coverage && cat ./coverage/lcov.info | npx coveralls"


### PR DESCRIPTION
Had an incorrect file path for babel build script. updated to use `server` instead of `src`